### PR TITLE
Fix for template and troubleshoot lab

### DIFF
--- a/labs/template-and-file/compute/main.tf
+++ b/labs/template-and-file/compute/main.tf
@@ -1,12 +1,8 @@
 #-----compute/main.tf
 
 data "aws_ami" "server_ami" {
+  owners = ["amazon"]
   most_recent = true
-
-  filter {
-    name   = "owner-alias"
-    values = ["amazon"]
-  }
 
   filter {
     name   = "name"

--- a/labs/troubleshooting-aws/compute/main.tf
+++ b/labs/troubleshooting-aws/compute/main.tf
@@ -1,12 +1,8 @@
 #-----compute/main.tf
 
 data "aws_ami" "server_ami" {
+  owners = ["amazon"]
   most_recent = true
-
-  filter {
-    name   = "owner-alias"
-    values = ["amazon"]
-  }
 
   filter {
     name   = "name"


### PR DESCRIPTION
aws_ami data source now requires an "owners" argument
https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#data-source-aws_ami